### PR TITLE
Avoid manually updating things that can be automated

### DIFF
--- a/_includes/calc_attendance.html
+++ b/_includes/calc_attendance.html
@@ -1,0 +1,123 @@
+{% comment %}
+  Calculate previous meetings and OOE/IMOVE orgs for attendance and votes pages.
+  This replaces manual front matter fields.
+{% endcomment %}
+
+{% if page.year and page.month %}
+  {% comment %} Find all attendance pages and sort them by year and month {% endcomment %}
+  {% assign attendance_pages = "" | split: ',' %}
+  {% for p in site.pages %}
+    {% if p.layout == "attendance" and p.year and p.month %}
+      {% assign attendance_pages = attendance_pages | push: p %}
+    {% endif %}
+  {% endfor %}
+  
+  {% comment %} Build a list of year-month strings, sort them, then find matches {% endcomment %}
+  {% assign year_month_list = "" | split: ',' %}
+  {% for p in attendance_pages %}
+    {% assign ym = p.year | append: "-" | append: p.month %}
+    {% assign year_month_list = year_month_list | push: ym %}
+  {% endfor %}
+  {% assign sorted_ym = year_month_list | sort %}
+  
+  {% comment %} Find current page index {% endcomment %}
+  {% assign current_ym = page.year | append: "-" | append: page.month %}
+  {% assign current_index = -1 %}
+  {% for ym in sorted_ym %}
+    {% if ym == current_ym %}
+      {% assign current_index = forloop.index0 %}
+    {% endif %}
+  {% endfor %}
+  
+  {% comment %} Get previous two meetings if they exist {% endcomment %}
+  {% if current_index > 0 %}
+    {% assign prev_index = current_index | minus: 1 %}
+    {% assign prev_ym = sorted_ym[prev_index] %}
+    {% assign prev_parts = prev_ym | split: "-" %}
+    {% assign calc_prev_year = prev_parts[0] %}
+    {% assign calc_prev_month = prev_parts[1] %}
+  {% endif %}
+  
+  {% if current_index > 1 %}
+    {% assign prev_prev_index = current_index | minus: 2 %}
+    {% assign prev_prev_ym = sorted_ym[prev_prev_index] %}
+    {% assign prev_prev_parts = prev_prev_ym | split: "-" %}
+    {% assign calc_prev_prev_year = prev_prev_parts[0] %}
+    {% assign calc_prev_prev_month = prev_prev_parts[1] %}
+  {% endif %}
+  
+  {% comment %} Use calculated prev values if available, otherwise fall back to page front matter {% endcomment %}
+  {% assign use_prev_year = calc_prev_year | default: page.prev_year %}
+  {% assign use_prev_month = calc_prev_month | default: page.prev_month %}
+  {% assign use_prev_prev_year = calc_prev_prev_year | default: page.prev_prev_year %}
+  {% assign use_prev_prev_month = calc_prev_prev_month | default: page.prev_prev_month %}
+  
+  {% if use_prev_year != nil %}
+    {% assign cur_attend = site.data.meetings[page.year][page.month].attendance %}
+    {% assign calc_prev_orgs = "" | split: ',' %}
+    {% assign calc_prev_prev_orgs = "" | split: ',' %}
+    {% assign calc_registered_orgs = "" | split: ',' %}
+    {% assign calc_imove_orgs = "" | split: ',' %}
+    {% assign calc_ooe_orgs = "" | split: ',' %}
+    {% assign calc_ineligible_orgs = "" | split: ',' %}
+    
+    {% for person in site.data.meetings[use_prev_year][use_prev_month].attendance %}
+      {% if person.attend == "1" %}
+        {% unless person.org == "Self (Non-voting participant)" %}
+          {% assign org = person.org %}
+          {% for org_transition in site.data.orgs %}
+            {% if org_transition.old_org_name == org %}
+              {% assign calc_prev_orgs = calc_prev_orgs | push: org_transition.new_org_name | uniq %}
+            {% endif %}
+          {% endfor %}
+          {% assign calc_prev_orgs = calc_prev_orgs | push: org | uniq %}
+        {% endunless %}
+      {% endif %}
+    {% endfor %}
+    
+    {% for person in site.data.meetings[use_prev_prev_year][use_prev_prev_month].attendance %}
+      {% if person.attend == "1" %}
+        {% unless person.org == "Self (Non-voting participant)" %}
+          {% assign org = person.org %}
+          {% for org_transition in site.data.orgs %}
+            {% if org_transition.old_org_name == org %}
+              {% assign calc_prev_prev_orgs = calc_prev_prev_orgs | push: org_transition.new_org_name | uniq %}
+            {% endif %}
+          {% endfor %}
+          {% assign calc_prev_prev_orgs = calc_prev_prev_orgs | push: org | uniq %}
+        {% endunless %}
+      {% endif %}
+    {% endfor %}
+    
+    {% for person in cur_attend %}
+      {% if calc_prev_orgs contains person.org or calc_prev_prev_orgs contains person.org %}
+        {% if person.attend == "1" %}
+          {% unless person.org == "Self (Non-voting participant)" %}
+            {% assign calc_imove_orgs = calc_imove_orgs | push: person.org | uniq %}
+          {% endunless %}
+        {% else %}
+          {% unless calc_imove_orgs contains person.org %}
+            {% assign calc_ooe_orgs = calc_ooe_orgs | push: person.org | uniq %}
+          {% endunless %}
+        {% endif %}
+      {% else %}
+        {% unless calc_ineligible_orgs contains person.org %}
+          {% assign calc_ineligible_orgs = calc_ineligible_orgs | push: person.org %}
+        {% endunless %}
+      {% endif %}
+      {% unless calc_registered_orgs contains person.org %}
+        {% unless person.org == "Self (Non-voting participant)" %}
+          {% assign calc_registered_orgs = calc_registered_orgs | push: person.org %}
+        {% endunless %}
+      {% endunless %}
+    {% endfor %}
+    
+    {% assign calc_ooe = calc_ooe_orgs.size | plus: calc_imove_orgs.size %}
+    {% assign calc_prev_ooe = 0 %}
+    {% for p in site.pages %}
+      {% if p.year == use_prev_year and p.month == use_prev_month %}
+        {% assign calc_prev_ooe = p.ooe %}
+      {% endif %}
+    {% endfor %}
+  {% endif %}
+{% endif %}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -3,59 +3,133 @@
   This replaces the manual prev_year, prev_month, prev_prev_year, prev_prev_month
   front matter in attendance.md files.
 {% endcomment %}
-{% if page.layout == "attendance" and page.year and page.month %}
-  {% comment %} Find all attendance pages and sort them by year and month {% endcomment %}
-  {% assign attendance_pages = "" | split: ',' %}
-  {% for p in site.pages %}
-    {% if p.layout == "attendance" and p.year and p.month %}
-      {% assign attendance_pages = attendance_pages | push: p %}
+{% if page.layout == "attendance" or page.layout == "votes" %}
+  {% if page.year and page.month %}
+    {% comment %} Find all attendance pages and sort them by year and month {% endcomment %}
+    {% assign attendance_pages = "" | split: ',' %}
+    {% for p in site.pages %}
+      {% if p.layout == "attendance" and p.year and p.month %}
+        {% assign attendance_pages = attendance_pages | push: p %}
+      {% endif %}
+    {% endfor %}
+    
+    {% comment %} Build a list of year-month strings, sort them, then find matches {% endcomment %}
+    {% assign year_month_list = "" | split: ',' %}
+    {% for p in attendance_pages %}
+      {% assign ym = p.year | append: "-" | append: p.month %}
+      {% assign year_month_list = year_month_list | push: ym %}
+    {% endfor %}
+    {% assign sorted_ym = year_month_list | sort %}
+    
+    {% comment %} Find current page index {% endcomment %}
+    {% assign current_ym = page.year | append: "-" | append: page.month %}
+    {% assign current_index = -1 %}
+    {% for ym in sorted_ym %}
+      {% if ym == current_ym %}
+        {% assign current_index = forloop.index0 %}
+      {% endif %}
+    {% endfor %}
+    
+    {% comment %} Get previous two meetings if they exist {% endcomment %}
+    {% if current_index > 0 %}
+      {% assign prev_index = current_index | minus: 1 %}
+      {% assign prev_ym = sorted_ym[prev_index] %}
+      {% assign prev_parts = prev_ym | split: "-" %}
+      {% assign calc_prev_year = prev_parts[0] %}
+      {% assign calc_prev_month = prev_parts[1] %}
     {% endif %}
-  {% endfor %}
-  
-  {% comment %} Sort by year then month (both are strings, so we need to handle sorting) {% endcomment %}
-  {% assign sorted_pages = attendance_pages | sort: "year" | sort: "month" %}
-  
-  {% comment %} Actually, the above won't work correctly for year/month sorting.
-     Let's create a sortable key and sort manually. {% endcomment %}
-  {% assign pages_with_key = "" | split: ',' %}
-  {% for p in attendance_pages %}
-    {% assign year_month = p.year | append: "-" | append: p.month %}
-    {% assign page_with_key = p | hash: "sort_key", year_month %}
-    {% comment %} Liquid doesn't have a good way to add a key, so we'll use a different approach {% endcomment %}
-  {% endfor %}
-  
-  {% comment %} Simpler approach: build a list of year-month strings, sort them, then find matches {% endcomment %}
-  {% assign year_month_list = "" | split: ',' %}
-  {% for p in attendance_pages %}
-    {% assign ym = p.year | append: "-" | append: p.month %}
-    {% assign year_month_list = year_month_list | push: ym %}
-  {% endfor %}
-  {% assign sorted_ym = year_month_list | sort %}
-  
-  {% comment %} Find current page index {% endcomment %}
-  {% assign current_ym = page.year | append: "-" | append: page.month %}
-  {% assign current_index = -1 %}
-  {% for ym in sorted_ym %}
-    {% if ym == current_ym %}
-      {% assign current_index = forloop.index0 %}
+    
+    {% if current_index > 1 %}
+      {% assign prev_prev_index = current_index | minus: 2 %}
+      {% assign prev_prev_ym = sorted_ym[prev_prev_index] %}
+      {% assign prev_prev_parts = prev_prev_ym | split: "-" %}
+      {% assign calc_prev_prev_year = prev_prev_parts[0] %}
+      {% assign calc_prev_prev_month = prev_prev_parts[1] %}
     {% endif %}
-  {% endfor %}
-  
-  {% comment %} Get previous two meetings if they exist {% endcomment %}
-  {% if current_index > 0 %}
-    {% assign prev_index = current_index | minus: 1 %}
-    {% assign prev_ym = sorted_ym[prev_index] %}
-    {% assign prev_parts = prev_ym | split: "-" %}
-    {% assign calc_prev_year = prev_parts[0] %}
-    {% assign calc_prev_month = prev_parts[1] %}
   {% endif %}
-  
-  {% if current_index > 1 %}
-    {% assign prev_prev_index = current_index | minus: 2 %}
-    {% assign prev_prev_ym = sorted_ym[prev_prev_index] %}
-    {% assign prev_prev_parts = prev_prev_ym | split: "-" %}
-    {% assign calc_prev_prev_year = prev_prev_parts[0] %}
-    {% assign calc_prev_prev_month = prev_prev_parts[1] %}
+{% endif %}
+
+{% comment %}
+  Calculate OOE and IMOVE orgs for attendance and votes pages.
+  OOE = orgs that attended 2 of last 3 meetings
+  IMOVE = OOE orgs that are also present at current meeting
+{% endcomment %}
+{% if page.layout == "attendance" or page.layout == "votes" %}
+  {% if page.year and page.month %}
+    {% comment %} Use calculated prev values if available, otherwise fall back to page front matter {% endcomment %}
+    {% assign use_prev_year = calc_prev_year | default: page.prev_year %}
+    {% assign use_prev_month = calc_prev_month | default: page.prev_month %}
+    {% assign use_prev_prev_year = calc_prev_prev_year | default: page.prev_prev_year %}
+    {% assign use_prev_prev_month = calc_prev_prev_month | default: page.prev_prev_month %}
+    
+    {% if use_prev_year != nil %}
+      {% assign cur_attend = site.data.meetings[page.year][page.month].attendance %}
+      {% assign calc_prev_orgs = "" | split: ',' %}
+      {% assign calc_prev_prev_orgs = "" | split: ',' %}
+      {% assign calc_registered_orgs = "" | split: ',' %}
+      {% assign calc_imove_orgs = "" | split: ',' %}
+      {% assign calc_ooe_orgs = "" | split: ',' %}
+      {% assign calc_ineligible_orgs = "" | split: ',' %}
+      
+      {% for person in site.data.meetings[use_prev_year][use_prev_month].attendance %}
+        {% if person.attend == "1" %}
+          {% unless person.org == "Self (Non-voting participant)" %}
+            {% assign org = person.org %}
+            {% for org_transition in site.data.orgs %}
+              {% if org_transition.old_org_name == org %}
+                {% assign calc_prev_orgs = calc_prev_orgs | push: org_transition.new_org_name | uniq %}
+              {% endif %}
+            {% endfor %}
+            {% assign calc_prev_orgs = calc_prev_orgs | push: org | uniq %}
+          {% endunless %}
+        {% endif %}
+      {% endfor %}
+      
+      {% for person in site.data.meetings[use_prev_prev_year][use_prev_prev_month].attendance %}
+        {% if person.attend == "1" %}
+          {% unless person.org == "Self (Non-voting participant)" %}
+            {% assign org = person.org %}
+            {% for org_transition in site.data.orgs %}
+              {% if org_transition.old_org_name == org %}
+                {% assign calc_prev_prev_orgs = calc_prev_prev_orgs | push: org_transition.new_org_name | uniq %}
+              {% endif %}
+            {% endfor %}
+            {% assign calc_prev_prev_orgs = calc_prev_prev_orgs | push: org | uniq %}
+          {% endunless %}
+        {% endif %}
+      {% endfor %}
+      
+      {% for person in cur_attend %}
+        {% if calc_prev_orgs contains person.org or calc_prev_prev_orgs contains person.org %}
+          {% if person.attend == "1" %}
+            {% unless person.org == "Self (Non-voting participant)" %}
+              {% assign calc_imove_orgs = calc_imove_orgs | push: person.org | uniq %}
+            {% endunless %}
+          {% else %}
+            {% unless calc_imove_orgs contains person.org %}
+              {% assign calc_ooe_orgs = calc_ooe_orgs | push: person.org | uniq %}
+            {% endunless %}
+          {% endif %}
+        {% else %}
+          {% unless calc_ineligible_orgs contains person.org %}
+            {% assign calc_ineligible_orgs = calc_ineligible_orgs | push: person.org %}
+          {% endunless %}
+        {% endif %}
+        {% unless calc_registered_orgs contains person.org %}
+          {% unless person.org == "Self (Non-voting participant)" %}
+            {% assign calc_registered_orgs = calc_registered_orgs | push: person.org %}
+          {% endunless %}
+        {% endunless %}
+      {% endfor %}
+      
+      {% assign calc_ooe = calc_ooe_orgs.size | plus: calc_imove_orgs.size %}
+      {% assign calc_prev_ooe = 0 %}
+      {% for p in site.pages %}
+        {% if p.year == use_prev_year and p.month == use_prev_month %}
+          {% assign calc_prev_ooe = p.ooe %}
+        {% endif %}
+      {% endfor %}
+    {% endif %}
   {% endif %}
 {% endif %}
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,3 +1,67 @@
+{% comment %}
+  Automatically calculate previous meetings for attendance pages.
+  This replaces the manual prev_year, prev_month, prev_prev_year, prev_prev_month
+  front matter in attendance.md files.
+{% endcomment %}
+{% if page.layout == "attendance" and page.year and page.month %}
+  {% comment %} Find all attendance pages and sort them by year and month {% endcomment %}
+  {% assign attendance_pages = "" | split: ',' %}
+  {% for p in site.pages %}
+    {% if p.layout == "attendance" and p.year and p.month %}
+      {% assign attendance_pages = attendance_pages | push: p %}
+    {% endif %}
+  {% endfor %}
+  
+  {% comment %} Sort by year then month (both are strings, so we need to handle sorting) {% endcomment %}
+  {% assign sorted_pages = attendance_pages | sort: "year" | sort: "month" %}
+  
+  {% comment %} Actually, the above won't work correctly for year/month sorting.
+     Let's create a sortable key and sort manually. {% endcomment %}
+  {% assign pages_with_key = "" | split: ',' %}
+  {% for p in attendance_pages %}
+    {% assign year_month = p.year | append: "-" | append: p.month %}
+    {% assign page_with_key = p | hash: "sort_key", year_month %}
+    {% comment %} Liquid doesn't have a good way to add a key, so we'll use a different approach {% endcomment %}
+  {% endfor %}
+  
+  {% comment %} Simpler approach: build a list of year-month strings, sort them, then find matches {% endcomment %}
+  {% assign year_month_list = "" | split: ',' %}
+  {% for p in attendance_pages %}
+    {% assign ym = p.year | append: "-" | append: p.month %}
+    {% assign year_month_list = year_month_list | push: ym %}
+  {% endfor %}
+  {% assign sorted_ym = year_month_list | sort %}
+  
+  {% comment %} Find current page index {% endcomment %}
+  {% assign current_ym = page.year | append: "-" | append: page.month %}
+  {% assign current_index = -1 %}
+  {% for ym in sorted_ym %}
+    {% if ym == current_ym %}
+      {% assign current_index = forloop.index0 %}
+    {% endif %}
+  {% endfor %}
+  
+  {% comment %} Get previous two meetings if they exist {% endcomment %}
+  {% if current_index > 0 %}
+    {% assign prev_index = current_index | minus: 1 %}
+    {% assign prev_ym = sorted_ym[prev_index] %}
+    {% assign prev_parts = prev_ym | split: "-" %}
+    {% assign calc_prev_year = prev_parts[0] %}
+    {% assign calc_prev_month = prev_parts[1] %}
+  {% endif %}
+  
+  {% if current_index > 1 %}
+    {% assign prev_prev_index = current_index | minus: 2 %}
+    {% assign prev_prev_ym = sorted_ym[prev_prev_index] %}
+    {% assign prev_prev_parts = prev_prev_ym | split: "-" %}
+    {% assign calc_prev_prev_year = prev_prev_parts[0] %}
+    {% assign calc_prev_prev_month = prev_prev_parts[1] %}
+  {% endif %}
+{% endif %}
+
+{% comment %} Skip HTML output if calc_only parameter is set {% endcomment %}
+{% unless include.calc_only %}
+
 <!-- TODO this file has become a mess, refactor it -->
 
 {% if page.bigimg or page.title %}
@@ -74,3 +138,5 @@
 {% else %}
 <div class="intro-header"></div>
 {% endif %}
+
+{% endunless %}

--- a/_layouts/attendance.html
+++ b/_layouts/attendance.html
@@ -2,6 +2,9 @@
 layout: default
 ---
 
+{% comment %} Include header.html to calculate previous meetings automatically {% endcomment %}
+{% include header.html calc_only=true %}
+
 <article class="post">
 
     <header class="post-header">
@@ -50,7 +53,13 @@ layout: default
             {% endfor %}
           {% endif %}
         </ol>
-        {% if page.prev_year != nil %}
+        {% comment %} Use calculated values if available, otherwise fall back to page front matter {% endcomment %}
+        {% assign use_prev_year = calc_prev_year | default: page.prev_year %}
+        {% assign use_prev_month = calc_prev_month | default: page.prev_month %}
+        {% assign use_prev_prev_year = calc_prev_prev_year | default: page.prev_prev_year %}
+        {% assign use_prev_prev_month = calc_prev_prev_month | default: page.prev_prev_month %}
+        
+        {% if use_prev_year != nil %}
           {% assign cur_attend = site.data.meetings[page.year][page.month].attendance %}
           {% assign prev_orgs = "" | split: ',' %}
           {% assign prev_prev_orgs = "" | split: ',' %}
@@ -58,7 +67,7 @@ layout: default
           {% assign imove_orgs = "" | split: ',' %}
           {% assign ooe_orgs = "" | split: ',' %}
           {% assign ineligible_orgs = "" | split: ',' %}
-          {% for person in site.data.meetings[page.prev_year][page.prev_month].attendance %}
+          {% for person in site.data.meetings[use_prev_year][use_prev_month].attendance %}
             {% if person.attend == "1" %}
               {% unless person.org == "Self (Non-voting participant)" %}
                 {% assign org = person.org %}
@@ -71,7 +80,7 @@ layout: default
               {% endunless %}
             {% endif %}
           {% endfor %}
-          {% for person in site.data.meetings[page.prev_prev_year][page.prev_prev_month].attendance %}
+          {% for person in site.data.meetings[use_prev_prev_year][use_prev_prev_month].attendance %}
             {% if person.attend == "1" %}
               {% unless person.org == "Self (Non-voting participant)" %}
                 {% assign org = person.org %}
@@ -109,7 +118,7 @@ layout: default
           {% assign ooe = ooe_orgs.size | plus: imove_orgs.size %}
           {% assign prev_ooe = 0 %}
           {% for p in site.pages %}
-            {% if p.year == page.prev_year and p.month == page.prev_month %}
+            {% if p.year == use_prev_year and p.month == use_prev_month %}
               {% assign prev_ooe = p.ooe %}
             {% endif %}
           {% endfor %}

--- a/_layouts/attendance.html
+++ b/_layouts/attendance.html
@@ -2,8 +2,8 @@
 layout: default
 ---
 
-{% comment %} Include header.html to calculate previous meetings automatically {% endcomment %}
-{% include header.html calc_only=true %}
+{% comment %} Include calc_attendance.html to calculate previous meetings and OOE/IMOVE automatically {% endcomment %}
+{% include calc_attendance.html %}
 
 <article class="post">
 
@@ -53,95 +53,37 @@ layout: default
             {% endfor %}
           {% endif %}
         </ol>
-        {% comment %} Use calculated values if available, otherwise fall back to page front matter {% endcomment %}
-        {% assign use_prev_year = calc_prev_year | default: page.prev_year %}
-        {% assign use_prev_month = calc_prev_month | default: page.prev_month %}
-        {% assign use_prev_prev_year = calc_prev_prev_year | default: page.prev_prev_year %}
-        {% assign use_prev_prev_month = calc_prev_prev_month | default: page.prev_prev_month %}
-        
-        {% if use_prev_year != nil %}
-          {% assign cur_attend = site.data.meetings[page.year][page.month].attendance %}
-          {% assign prev_orgs = "" | split: ',' %}
-          {% assign prev_prev_orgs = "" | split: ',' %}
-          {% assign registered_orgs = "" | split: ',' %}
-          {% assign imove_orgs = "" | split: ',' %}
-          {% assign ooe_orgs = "" | split: ',' %}
-          {% assign ineligible_orgs = "" | split: ',' %}
-          {% for person in site.data.meetings[use_prev_year][use_prev_month].attendance %}
-            {% if person.attend == "1" %}
-              {% unless person.org == "Self (Non-voting participant)" %}
-                {% assign org = person.org %}
-                {% for org_transition in site.data.orgs %}
-                  {% if org_transition.old_org_name == org %}
-                    {% assign prev_orgs = prev_orgs | push: org_transition.new_org_name | uniq %}
-                  {% endif %}
-                {% endfor %}
-                {% assign prev_orgs = prev_orgs | push: org | uniq %}
-              {% endunless %}
-            {% endif %}
-          {% endfor %}
-          {% for person in site.data.meetings[use_prev_prev_year][use_prev_prev_month].attendance %}
-            {% if person.attend == "1" %}
-              {% unless person.org == "Self (Non-voting participant)" %}
-                {% assign org = person.org %}
-                {% for org_transition in site.data.orgs %}
-                  {% if org_transition.old_org_name == org %}
-                    {% assign prev_prev_orgs = prev_orgs | push: org_transition.new_org_name | uniq %}
-                  {% endif %}
-                {% endfor %}
-                {% assign prev_prev_orgs = prev_prev_orgs | push: org | uniq %}
-              {% endunless %}
-            {% endif %}
-          {% endfor %}
-          {% for person in cur_attend %}
-            {% if prev_orgs contains person.org or prev_prev_orgs contains person.org %}
-              {% if person.attend == "1" %}
-                {% unless person.org == "Self (Non-voting participant)" %}
-                  {% assign imove_orgs = imove_orgs | push: person.org | uniq %}
-                {% endunless %}
-              {% else %}
-                {% unless imove_orgs contains person.org %}
-                  {% assign ooe_orgs = ooe_orgs | push: person.org | uniq %}
-                {% endunless %}
-              {% endif %}
-            {% else %}
-              {% unless ineligible_orgs contains person.org %}
-                {% assign ineligible_orgs = ineligible_orgs | push: person.org %}
-              {% endunless %}
-            {% endif %}
-            {% unless registered_orgs contains person.org %}
-              {% unless person.org == "Self (Non-voting participant)" %}
-                {% assign registered_orgs = registered_orgs | push: person.org %}
-              {% endunless %}
-            {% endunless %}
-          {% endfor %}
-          {% assign ooe = ooe_orgs.size | plus: imove_orgs.size %}
-          {% assign prev_ooe = 0 %}
-          {% for p in site.pages %}
-            {% if p.year == use_prev_year and p.month == use_prev_month %}
-              {% assign prev_ooe = p.ooe %}
-            {% endif %}
-          {% endfor %}
-          <h3> Voting Eligibile Orgs ({{imove_orgs.size}} of {{ prev_ooe | times: 0.66 | ceil }} needed) </h3>
-          {% assign imove_orgs = imove_orgs | sort %}
-          {% for org in imove_orgs %} <li> {{ org }}</li> {{newline}} {% endfor %}
+        {% comment %} Use calculated values from header.html if available {% endcomment %}
+        {% if calc_prev_year != nil or page.prev_year != nil %}
+          {% assign use_prev_orgs = calc_prev_orgs %}
+          {% assign use_prev_prev_orgs = calc_prev_prev_orgs %}
+          {% assign use_registered_orgs = calc_registered_orgs %}
+          {% assign use_imove_orgs = calc_imove_orgs %}
+          {% assign use_ooe_orgs = calc_ooe_orgs %}
+          {% assign use_ineligible_orgs = calc_ineligible_orgs %}
+          {% assign use_ooe = calc_ooe %}
+          {% assign use_prev_ooe = calc_prev_ooe %}
+          
+          <h3> Voting Eligibile Orgs ({{use_imove_orgs.size}} of {{ use_prev_ooe | times: 0.66 | ceil }} needed) </h3>
+          {% assign sorted_imove = use_imove_orgs | sort %}
+          {% for org in sorted_imove %} <li> {{ org }}</li> {{newline}} {% endfor %}
           <!-- This code is a mess because when I split it out across multiple lines, it adds a bunch of blank lines in the output -->
           <h3> Ineligible Orgs </h3>
           <h4> Not Present at Current Meeting for First Vote </h4>
-            {% assign ooe_orgs = ooe_orgs | sort %}
-            {% for org in ooe_orgs %}{% unless imove_orgs contains org %} <li> {{ org }} </li> {% endunless %} {% endfor %}
+            {% assign sorted_ooe = use_ooe_orgs | sort %}
+            {% for org in sorted_ooe %}{% unless use_imove_orgs contains org %} <li> {{ org }} </li> {% endunless %} {% endfor %}
             <h4> Did Not Attend 2 of 3 Recent Meetings </h4>
-            {% assign ineligible_orgs = ineligible_orgs | sort %}{% for org in ineligible_orgs %}{% unless org == "Self (Non-voting participant)" %} <li> {{ org }} </li> {{newline}} {% endunless %} {% endfor %}
+            {% assign sorted_ineligible = use_ineligible_orgs | sort %}{% for org in sorted_ineligible %}{% unless org == "Self (Non-voting participant)" %} <li> {{ org }} </li> {{newline}} {% endunless %} {% endfor %}
            <h4> Did Not Register for Current Meeting </h4>
-           {% for org in prev_orgs %}{% unless imove_orgs contains org or ooe_orgs contains org %}{% unless org == "Self (Non-voting participant)" %} <li> {{ org }} </li> {{newline}} {% endunless %}{% endunless %} {% endfor %}
-           {% for org in prev_prev_orgs %}{% unless imove_orgs contains org or ooe_orgs contains org or prev_orgs contains org %}{% unless org == "Self (Non-voting participant)" %} <li> {{ org }} </li> {{newline}} {% endunless %}{% endunless %}{% endfor %}
+           {% for org in use_prev_orgs %}{% unless use_imove_orgs contains org or use_ooe_orgs contains org %}{% unless org == "Self (Non-voting participant)" %} <li> {{ org }} </li> {{newline}} {% endunless %}{% endunless %} {% endfor %}
+           {% for org in use_prev_prev_orgs %}{% unless use_imove_orgs contains org or use_ooe_orgs contains org or use_prev_orgs contains org %}{% unless org == "Self (Non-voting participant)" %} <li> {{ org }} </li> {{newline}} {% endunless %}{% endunless %}{% endfor %}
         {% endif %}
 
           <h3> Stats </h3>
           <ul>
-            <li>Registered Orgs: {{registered_orgs.size}}</li>
-            <li>OOE Orgs: {{ooe}}</li>
-            <li>IMOVE Orgs: {{imove_orgs.size}}</li>
+            <li>Registered Orgs: {{use_registered_orgs.size}}</li>
+            <li>OOE Orgs: {{use_ooe}}</li>
+            <li>IMOVE Orgs: {{use_imove_orgs.size}}</li>
           </ul>
 
     </div>

--- a/_layouts/votes.html
+++ b/_layouts/votes.html
@@ -2,6 +2,9 @@
 layout: default
 ---
 
+{% comment %} Include calc_attendance.html to calculate OOE/IMOVE automatically {% endcomment %}
+{% include calc_attendance.html %}
+
 <script>
     function ballot(rules, yes, no, abstain, missed, type, imove) {
         if (yes == 0 && no == 0 && abstain == 0 && missed == 0) {
@@ -122,10 +125,14 @@ layout: default
     }
 </script>
 
-{% if page.imove.size > 0 %}
-{% assign imove = page.imove %}
+{% comment %} Use calculated IMOVE if available, otherwise fall back to page front matter {% endcomment %}
+{% assign calc_imove_size = calc_imove_orgs.size | default: 0 %}
+{% if calc_imove_size > 0 %}
+  {% assign imove = calc_imove_size %}
+{% elsif page.imove.size > 0 %}
+  {% assign imove = page.imove %}
 {% else %}
-{% assign imove = 0 %}
+  {% assign imove = 0 %}
 {% endif %}
 
 <article class="post">
@@ -151,20 +158,25 @@ layout: default
         {% assign url = "https://github.com/mpi-forum/mpi-issues/issues/" %}
         {% assign pr_url = "https://github.com/mpi-forum/mpi-standard/pull/" %}
 
-        {% if page.registered > 0 %}
-        <b>Registered:</b> {{ page.registered }}<br>
+        {% comment %} Use calculated values if available, otherwise fall back to page front matter {% endcomment %}
+        {% assign use_registered = calc_registered_orgs.size | default: page.registered %}
+        {% assign use_ooe = calc_ooe | default: page.ooe %}
+        {% assign use_imove = imove %}
+        
+        {% if use_registered > 0 %}
+        <b>Registered:</b> {{ use_registered }}<br>
         {% endif %}
         {% if page.attended > 0 %}
         <b>Attended:</b> {{ page.attended }}<br>
         {% endif %}
-        {% if page.ooe > 0 %}
-        <b>OOE:</b> {{ page.ooe }}<br>
+        {% if use_ooe > 0 %}
+        <b>OOE:</b> {{ use_ooe }}<br>
         {% endif %}
-        {% if page.imove > 0 %}
-        <b>IMOVE:</b> {{ imove }}<br>
+        {% if use_imove > 0 %}
+        <b>IMOVE:</b> {{ use_imove }}<br>
         {% endif %}
-        {% if page.imove > 0 %}
-        <b>Votes needed for individual vote quorum:</b> <script> document.write(Math.ceil((3/4) * {{imove}})); </script> <br>
+        {% if use_imove > 0 %}
+        <b>Votes needed for individual vote quorum:</b> <script> document.write(Math.ceil((3/4) * {{use_imove}})); </script> <br>
         {% endif %}
         <br>
 

--- a/meetings/2013/06/votes.md
+++ b/meetings/2013/06/votes.md
@@ -5,8 +5,5 @@ year: "2013"
 month: "06"
 rules: 3152013
 permalink: meetings/2013/06/votes
-registered:
-attended:
 ooe:
-imove: 19
 ---

--- a/meetings/2013/09/votes.md
+++ b/meetings/2013/09/votes.md
@@ -5,8 +5,5 @@ year: "2013"
 month: "09"
 rules: 3152013
 permalink: meetings/2013/09/votes
-registered: 19
-attended: 19
 ooe: 23
-imove: 14
 ---

--- a/meetings/2013/12/votes.md
+++ b/meetings/2013/12/votes.md
@@ -5,8 +5,5 @@ year: "2013"
 month: "12"
 rules: 3152013
 permalink: meetings/2013/12/votes
-registered: 19
-attended: 20
 ooe: 21
-imove: 19
 ---

--- a/meetings/2014/03/votes.md
+++ b/meetings/2014/03/votes.md
@@ -5,8 +5,5 @@ year: "2014"
 month: "03"
 rules: 3152013
 permalink: meetings/2014/03/votes
-registered: 18
-attended: 18
 ooe: 22
-imove: 18
 ---

--- a/meetings/2014/06/votes.md
+++ b/meetings/2014/06/votes.md
@@ -5,8 +5,5 @@ year: "2014"
 month: "06"
 rules: 3152013
 permalink: meetings/2014/06/votes
-registered: 20
-attended: 20
 ooe: 20
-imove: 19
 ---

--- a/meetings/2014/09/votes.md
+++ b/meetings/2014/09/votes.md
@@ -5,10 +5,7 @@ year: "2014"
 month: "09"
 rules: 3152013
 permalink: meetings/2014/09/votes
-registered: 20
-attended: 20
 ooe: 20
-imove: 19
 ---
 
 The meeting quorum was not met; there were no votes.

--- a/meetings/2014/12/votes.md
+++ b/meetings/2014/12/votes.md
@@ -5,8 +5,5 @@ year: "2014"
 month: "12"
 rules: 3152013
 permalink: meetings/2014/12/votes
-registered: 23
-attended: 23
 ooe: 23
-imove: 21
 ---

--- a/meetings/2015/06/votes.md
+++ b/meetings/2015/06/votes.md
@@ -5,10 +5,7 @@ year: "2015"
 month: "06"
 rules: 3152013
 permalink: meetings/2015/06/votes
-registered: 25
-attended: 24
 ooe: 25
-imove: 23
 ---
 
 Note for all but the final vote:

--- a/meetings/2016/02/votes.md
+++ b/meetings/2016/02/votes.md
@@ -5,8 +5,5 @@ year: "2016"
 month: "02"
 rules: 3152013
 permalink: meetings/2016/02/votes
-registered: 23
-attended: 23
 ooe: 23
-imove: 21
 ---

--- a/meetings/2016/06/votes.md
+++ b/meetings/2016/06/votes.md
@@ -5,8 +5,5 @@ year: "2016"
 month: "06"
 rules: 3152013
 permalink: meetings/2016/06/votes
-registered: 20
-attended: 20
 ooe: 21
-imove: 19
 ---

--- a/meetings/2016/09/votes.md
+++ b/meetings/2016/09/votes.md
@@ -5,8 +5,5 @@ year: "2016"
 month: "09"
 rules: 3152013
 permalink: meetings/2016/09/votes
-registered: 18
-attended: 18
 ooe: 24
-imove: 18
 ---

--- a/meetings/2016/12/votes.md
+++ b/meetings/2016/12/votes.md
@@ -5,8 +5,5 @@ year: "2016"
 month: "12"
 rules: 3152013
 permalink: meetings/2016/12/votes
-registered: 15
-attended: 15
 ooe: 18
-imove: 15
 ---

--- a/meetings/2017/02/votes.md
+++ b/meetings/2017/02/votes.md
@@ -5,8 +5,5 @@ year: "2017"
 month: "02"
 rules: 3152013
 permalink: meetings/2017/02/votes
-registered: 20
-attended: 20
 ooe: 20
-imove: 20
 ---

--- a/meetings/2017/06/votes.md
+++ b/meetings/2017/06/votes.md
@@ -5,10 +5,7 @@ year: "2017"
 month: "06"
 rules: 3152013
 permalink: meetings/2017/06/votes
-registered: 10
-attended: 10
 ooe: 18
-imove: 10
 ---
 
 Meeting did not meet quorum. No votes were held.

--- a/meetings/2017/09/votes.md
+++ b/meetings/2017/09/votes.md
@@ -5,7 +5,5 @@ year: "2017"
 month: "09"
 rules: 3152013
 permalink: meetings/2017/09/votes
-registered: 26
 ooe: 25
-imove: 23
 ---

--- a/meetings/2017/12/votes.md
+++ b/meetings/2017/12/votes.md
@@ -5,7 +5,5 @@ year: "2017"
 month: "12"
 rules: 3152013
 permalink: meetings/2017/12/votes
-registered: 22
 ooe: 24
-imove: 19
 ---

--- a/meetings/2018/02/votes.md
+++ b/meetings/2018/02/votes.md
@@ -5,7 +5,5 @@ year: "2018"
 month: "02"
 rules: 3152013
 permalink: meetings/2018/02/votes
-registered: 22
 ooe: 25
-imove: 22
 ---

--- a/meetings/2018/06/votes.md
+++ b/meetings/2018/06/votes.md
@@ -5,7 +5,5 @@ year: "2018"
 month: "06"
 rules: 3152013
 permalink: meetings/2018/06/votes
-registered: 22
 ooe: 22
-imove: 20
 ---

--- a/meetings/2018/09/votes.md
+++ b/meetings/2018/09/votes.md
@@ -5,7 +5,5 @@ year: "2018"
 month: "09"
 rules: 3152013
 permalink: meetings/2018/09/votes
-registered: 23
 ooe: 21
-imove: 16
 ---

--- a/meetings/2018/12/votes.md
+++ b/meetings/2018/12/votes.md
@@ -5,7 +5,5 @@ year: "2018"
 month: "12"
 rules: 3152013
 permalink: meetings/2018/12/votes
-registered: 23
 ooe: 22
-imove: 20
 ---

--- a/meetings/2019/03/votes.md
+++ b/meetings/2019/03/votes.md
@@ -12,11 +12,9 @@ rules: 3152013
 
 permalink: meetings/2019/03/votes
 
-registered: 
 
 ooe: 
 
-imove: 
 
 ---
 

--- a/meetings/2019/05/votes.md
+++ b/meetings/2019/05/votes.md
@@ -5,8 +5,6 @@ year: "2019"
 month: "05"
 rules: 3152013
 permalink: meetings/2019/05/votes
-registered: 24
 ooe: 26
-imove: 24
 ---
 

--- a/meetings/2019/09/votes.md
+++ b/meetings/2019/09/votes.md
@@ -5,8 +5,6 @@ year: "2019"
 month: "09"
 rules: 3152013
 permalink: meetings/2019/09/votes
-registered: 22
 ooe: 26
-imove: 21
 ---
 

--- a/meetings/2019/12/votes.md
+++ b/meetings/2019/12/votes.md
@@ -5,9 +5,7 @@ year: "2019"
 month: "12"
 rules: 3152013
 permalink: meetings/2019/12/votes
-registered: 27
 ooe: 25
-imove: 24
 ---
 
 As HPE completed its acquisition of Cray Inc. on September 25, 2019, this is the first meeting where

--- a/meetings/2020/02/votes.md
+++ b/meetings/2020/02/votes.md
@@ -5,8 +5,6 @@ year: "2020"
 month: "02"
 rules: 3152013
 permalink: meetings/2020/02/votes
-registered: 28
 ooe: 28
-imove: 24
 ---
 

--- a/meetings/2020/05/votes.md
+++ b/meetings/2020/05/votes.md
@@ -5,9 +5,7 @@ year: "2020"
 month: "05"
 rules: 3152013
 permalink: meetings/2020/05/votes
-registered: 31
 ooe: 30
-imove: 27
 ---
 
 As NVIDIA completed its acquisition of Mellanox Inc. on April 27, 2020, this is the first meeting

--- a/meetings/2020/06/votes.md
+++ b/meetings/2020/06/votes.md
@@ -5,8 +5,6 @@ year: "2020"
 month: "06"
 rules: 3152013
 permalink: meetings/2020/06/votes
-registered: 37
 ooe: 31
-imove: 31
 ---
 

--- a/meetings/2020/08/votes.md
+++ b/meetings/2020/08/votes.md
@@ -5,8 +5,6 @@ year: "2020"
 month: "08"
 rules: 3152013
 permalink: meetings/2020/08/votes
-registered: 30
 ooe: 32
-imove: 30
 ---
 

--- a/meetings/2020/09/votes.md
+++ b/meetings/2020/09/votes.md
@@ -5,8 +5,6 @@ year: "2020"
 month: "09"
 rules: 3152013
 permalink: meetings/2020/09/votes
-registered: 34
 ooe: 32
-imove: 31
 ---
 

--- a/meetings/2020/11/votes.md
+++ b/meetings/2020/11/votes.md
@@ -5,8 +5,6 @@ year: "2020"
 month: "11"
 rules: 3152013
 permalink: meetings/2020/11/votes
-registered:
 ooe:
-imove:
 ---
 

--- a/meetings/2020/12/votes.md
+++ b/meetings/2020/12/votes.md
@@ -5,8 +5,6 @@ year: "2020"
 month: "12"
 rules: 3152013
 permalink: meetings/2020/12/votes
-registered: 39
 ooe: 32
-imove: 29
 ---
 

--- a/meetings/2021/02/attendance.md
+++ b/meetings/2021/02/attendance.md
@@ -4,8 +4,4 @@ date: February 22, 2021 - February 25, 2021
 permalink: meetings/2021/02/attendance
 year: "2021"
 month: "02"
-prev_year: "2021"
-prev_month: "02"
-prev_prev_year: "2020"
-prev_prev_month: "12"
 ---

--- a/meetings/2021/02/votes.md
+++ b/meetings/2021/02/votes.md
@@ -5,8 +5,6 @@ year: "2021"
 month: "02"
 rules: 3152013
 permalink: meetings/2021/02/votes
-registered: 38
 ooe: 34
-imove: 33
 ---
 

--- a/meetings/2021/06/attendance.md
+++ b/meetings/2021/06/attendance.md
@@ -4,8 +4,4 @@ date: June 07, 2021 - June 09, 2021
 permalink: meetings/2021/06/attendance
 year: "2021"
 month: "06"
-prev_year: "2021"
-prev_month: "06"
-prev_prev_year: "2021"
-prev_prev_month: "02"
 ---

--- a/meetings/2021/06/votes.md
+++ b/meetings/2021/06/votes.md
@@ -5,9 +5,7 @@ year: "2021"
 month: "06"
 rules: 3152013
 permalink: meetings/2021/06/votes
-registered: 37
 ooe: 37
-imove: 36
 ---
 
 ## Officer Election Results

--- a/meetings/2021/09/attendance.md
+++ b/meetings/2021/09/attendance.md
@@ -4,8 +4,4 @@ date: September 08, 2021 - September 10, 2021
 permalink: meetings/2021/09/attendance
 year: "2021"
 month: "09"
-prev_year: "2021"
-prev_month: "06"
-prev_prev_year: "2021"
-prev_prev_month: "02"
 ---

--- a/meetings/2021/09/votes.md
+++ b/meetings/2021/09/votes.md
@@ -5,8 +5,6 @@ year: "2021"
 month: "09"
 rules: 3152013
 permalink: meetings/2021/09/votes
-registered: 38
 ooe: 37
-imove: 30
 ---
 

--- a/meetings/2021/12/attendance.md
+++ b/meetings/2021/12/attendance.md
@@ -4,8 +4,4 @@ date: December 06, 2021 - December 09, 2021
 permalink: meetings/2021/12/attendance
 year: "2021"
 month: "12"
-prev_year: "2021"
-prev_month: "09"
-prev_prev_year: "2021"
-prev_prev_month: "06"
 ---

--- a/meetings/2021/12/votes.md
+++ b/meetings/2021/12/votes.md
@@ -5,8 +5,6 @@ year: "2021"
 month: "12"
 rules: 3152013
 permalink: meetings/2021/12/votes
-registered: 34
 ooe: 35
-imove: 31
 ---
 

--- a/meetings/2022/02/attendance.md
+++ b/meetings/2022/02/attendance.md
@@ -4,8 +4,4 @@ date: February 28, 2022 - March 04, 2022
 permalink: meetings/2022/02/attendance
 year: "2022"
 month: "02"
-prev_year: "2021"
-prev_month: "12"
-prev_prev_year: "2021"
-prev_prev_month: "09"
 ---

--- a/meetings/2022/02/votes.md
+++ b/meetings/2022/02/votes.md
@@ -5,8 +5,6 @@ year: "2022"
 month: "02"
 rules: 3152013
 permalink: meetings/2022/02/votes
-registered: 36
 ooe: 35
-imove: 33
 ---
 

--- a/meetings/2022/05/attendance.md
+++ b/meetings/2022/05/attendance.md
@@ -4,8 +4,4 @@ date: May 23, 2022 - May 27, 2022
 permalink: meetings/2022/05/attendance
 year: "2022"
 month: "05"
-prev_year: "2022"
-prev_month: "02"
-prev_prev_year: "2021"
-prev_prev_month: "12"
 ---

--- a/meetings/2022/05/votes.md
+++ b/meetings/2022/05/votes.md
@@ -5,8 +5,6 @@ year: "2022"
 month: "05"
 rules: 3152013
 permalink: meetings/2022/05/votes
-registered: 35
 ooe: 34
-imove: 29
 ---
 

--- a/meetings/2022/09/attendance.md
+++ b/meetings/2022/09/attendance.md
@@ -4,8 +4,4 @@ date: September 28, 2022 - September 30, 2022
 permalink: meetings/2022/09/attendance
 year: "2022"
 month: "09"
-prev_year: "2022"
-prev_month: "05"
-prev_prev_year: "2022"
-prev_prev_month: "02"
 ---

--- a/meetings/2022/09/votes.md
+++ b/meetings/2022/09/votes.md
@@ -5,7 +5,5 @@ year: "2022"
 month: "09"
 rules: 3152013
 permalink: meetings/2022/09/votes
-registered: 31
 ooe: 35
-imove: 29
 ---

--- a/meetings/2022/12/attendance.md
+++ b/meetings/2022/12/attendance.md
@@ -4,9 +4,5 @@ date: December 05, 2022 - December 08, 2022
 permalink: meetings/2022/12/attendance
 year: "2022"
 month: "12"
-prev_year: "2022"
-prev_month: "09"
-prev_prev_year: "2022"
-prev_prev_month: "05"
 ---
 

--- a/meetings/2022/12/votes.md
+++ b/meetings/2022/12/votes.md
@@ -5,8 +5,6 @@ year: "2022"
 month: "12"
 rules: 3152013
 permalink: meetings/2022/12/votes
-registered: 35
 ooe: 34
-imove: 33
 ---
 

--- a/meetings/2023/02/attendance.md
+++ b/meetings/2023/02/attendance.md
@@ -4,9 +4,5 @@ date: February 01, 2023 and February 08, 2023
 permalink: meetings/2023/02/attendance
 year: "2023"
 month: "02"
-prev_year: "2022"
-prev_month: "12"
-prev_prev_year: "2022"
-prev_prev_month: "09"
 ---
 

--- a/meetings/2023/02/votes.md
+++ b/meetings/2023/02/votes.md
@@ -5,7 +5,5 @@ year: "2023"
 month: "02"
 rules: 3152013
 permalink: meetings/2023/02/votes
-registered: 35
 ooe: 35
-imove: 31
 ---

--- a/meetings/2023/03/attendance.md
+++ b/meetings/2023/03/attendance.md
@@ -4,8 +4,4 @@ date: March 13, 2023 - March 16, 2023
 permalink: meetings/2023/03/attendance
 year: "2023"
 month: "03"
-prev_year: "2023"
-prev_month: "02"
-prev_prev_year: "2022"
-prev_prev_month: "12"
 ---

--- a/meetings/2023/03/votes.md
+++ b/meetings/2023/03/votes.md
@@ -5,7 +5,5 @@ year: "2023"
 month: "03"
 rules: 3152013
 permalink: meetings/2023/03/votes
-registered: 34
 ooe: 34
-imove: 31
 ---

--- a/meetings/2023/05/attendance.md
+++ b/meetings/2023/05/attendance.md
@@ -4,9 +4,5 @@ date: May 02, 2023 - May 05, 2023
 permalink: meetings/2023/05/attendance
 year: "2023"
 month: "05"
-prev_year: "2023"
-prev_month: "03"
-prev_prev_year: "2023"
-prev_prev_month: "02"
 ---
 

--- a/meetings/2023/05/votes.md
+++ b/meetings/2023/05/votes.md
@@ -5,7 +5,5 @@ year: "2023"
 month: "05"
 rules: 3152013
 permalink: meetings/2023/05/votes
-registered: 35
 ooe: 37
-imove: 32
 ---

--- a/meetings/2023/07/attendance.md
+++ b/meetings/2023/07/attendance.md
@@ -4,9 +4,5 @@ date: July 10, 2023 - July 13, 2023
 permalink: meetings/2023/07/attendance
 year: "2023"
 month: "07"
-prev_year: "2023"
-prev_month: "05"
-prev_prev_year: "2023"
-prev_prev_month: "03"
 ---
 

--- a/meetings/2023/07/votes.md
+++ b/meetings/2023/07/votes.md
@@ -5,8 +5,6 @@ year: "2023"
 month: "07"
 rules: 3152013
 permalink: meetings/2023/07/votes
-registered: 35
 ooe: 37
-imove: 34
 ---
 

--- a/meetings/2023/09/attendance.md
+++ b/meetings/2023/09/attendance.md
@@ -4,9 +4,5 @@ date: September 13, 2023 - September 15, 2023
 permalink: meetings/2023/09/attendance
 year: "2023"
 month: "09"
-prev_year: "2023"
-prev_month: "07"
-prev_prev_year: "2023"
-prev_prev_month: "05"
 ---
 

--- a/meetings/2023/09/votes.md
+++ b/meetings/2023/09/votes.md
@@ -5,8 +5,6 @@ year: "2023"
 month: "09"
 rules: 3152013
 permalink: meetings/2023/09/votes
-registered: 31
 ooe: 30
-imove: 30
 ---
 

--- a/meetings/2023/10/attendance.md
+++ b/meetings/2023/10/attendance.md
@@ -4,9 +4,5 @@ date: October 31, 2023 - November 03, 2023
 permalink: meetings/2023/10/attendance
 year: "2023"
 month: "10"
-prev_year: "2023"
-prev_month: "09"
-prev_prev_year: "2023"
-prev_prev_month: "07"
 ---
 

--- a/meetings/2023/10/votes.md
+++ b/meetings/2023/10/votes.md
@@ -5,8 +5,6 @@ year: "2023"
 month: "10"
 rules: 3152013
 permalink: meetings/2023/10/votes
-registered: 35
 ooe: 36
-imove: 33
 ---
 

--- a/meetings/2023/12/attendance.md
+++ b/meetings/2023/12/attendance.md
@@ -4,9 +4,5 @@ date: December 04, 2023 - December 07, 2023
 permalink: meetings/2023/12/attendance
 year: "2023"
 month: "12"
-prev_year: "2023"
-prev_month: "10"
-prev_prev_year: "2023"
-prev_prev_month: "09"
 ---
 

--- a/meetings/2023/12/votes.md
+++ b/meetings/2023/12/votes.md
@@ -5,8 +5,6 @@ year: "2023"
 month: "12"
 rules: 3152013
 permalink: meetings/2023/12/votes
-registered: 33
 ooe: 35
-imove: 30
 ---
 

--- a/meetings/2024/03/attendance.md
+++ b/meetings/2024/03/attendance.md
@@ -4,10 +4,6 @@ date: March 18, 2024 - March 21, 2024
 permalink: meetings/2024/03/attendance
 year: "2024"
 month: "03"
-prev_year: "2023"
-prev_month: "12"
-prev_prev_year: "2023"
-prev_prev_month: "10"
 ---
 
 Beginning at this meeting, Eviden will assume the voting rights of Atos based

--- a/meetings/2024/03/votes.md
+++ b/meetings/2024/03/votes.md
@@ -5,9 +5,7 @@ year: "2024"
 month: "03"
 rules: 3152013
 permalink: meetings/2024/03/votes
-registered: 36
 ooe: 33
-imove: 32
 ---
 
 Beginning at this meeting, Eviden will assume the voting rights of Atos based

--- a/meetings/2024/06/attendance.md
+++ b/meetings/2024/06/attendance.md
@@ -4,9 +4,5 @@ date: June 17, 2024 - June 20, 2024
 permalink: meetings/2024/06/attendance
 year: "2024"
 month: "06"
-prev_year: "2024"
-prev_month: "03"
-prev_prev_year: "2023"
-prev_prev_month: "12"
 ---
 

--- a/meetings/2024/06/votes.md
+++ b/meetings/2024/06/votes.md
@@ -5,8 +5,6 @@ year: "2024"
 month: "06"
 rules: 3152013
 permalink: meetings/2024/06/votes
-registered: 31
 ooe: 29
-imove: 29
 ---
 

--- a/meetings/2024/09/attendance.md
+++ b/meetings/2024/09/attendance.md
@@ -4,9 +4,5 @@ date: September 23, 2024 - September 24, 2024
 permalink: meetings/2024/09/attendance
 year: "2024"
 month: "09"
-prev_year: "2024"
-prev_month: "06"
-prev_prev_year: "2024"
-prev_prev_month: "03"
 ---
 

--- a/meetings/2024/09/votes.md
+++ b/meetings/2024/09/votes.md
@@ -5,8 +5,6 @@ year: "2024"
 month: "09"
 rules: 3152013
 permalink: meetings/2024/09/votes
-registered: 32
 ooe: 30
-imove: 30
 ---
 

--- a/meetings/2024/12/attendance.md
+++ b/meetings/2024/12/attendance.md
@@ -4,9 +4,5 @@ date: December 09, 2024 - December 12, 2024
 permalink: meetings/2024/12/attendance
 year: "2024"
 month: "12"
-prev_year: "2024"
-prev_month: "09"
-prev_prev_year: "2024"
-prev_prev_month: "06"
 ---
 

--- a/meetings/2024/12/votes.md
+++ b/meetings/2024/12/votes.md
@@ -5,8 +5,6 @@ year: "2024"
 month: "12"
 rules: 3152013
 permalink: meetings/2024/12/votes
-registered: 33
 ooe: 29
-imove: 29
 ---
 

--- a/meetings/2025/01/attendance.md
+++ b/meetings/2025/01/attendance.md
@@ -4,9 +4,5 @@ date: January 08, 2025 - January 08, 2025
 permalink: meetings/2025/01/attendance
 year: "2025"
 month: "01"
-prev_year: "2024"
-prev_month: "12"
-prev_prev_year: "2024"
-prev_prev_month: "09"
 ---
 

--- a/meetings/2025/01/votes.md
+++ b/meetings/2025/01/votes.md
@@ -5,8 +5,6 @@ year: "2025"
 month: "01"
 rules: 3152013
 permalink: meetings/2025/01/votes
-registered: 30
 ooe: 30
-imove: 30
 ---
 

--- a/meetings/2025/03/attendance.md
+++ b/meetings/2025/03/attendance.md
@@ -4,9 +4,5 @@ date: March 03, 2025 - March 06, 2025
 permalink: meetings/2025/03/attendance
 year: "2025"
 month: "03"
-prev_year: "2025"
-prev_month: "01"
-prev_prev_year: "2024"
-prev_prev_month: "12"
 ---
 

--- a/meetings/2025/03/votes.md
+++ b/meetings/2025/03/votes.md
@@ -5,8 +5,6 @@ year: "2025"
 month: "03"
 rules: 3152013
 permalink: meetings/2025/03/votes
-registered: 33
 ooe: 31
-imove: 31
 ---
 

--- a/meetings/2025/06/attendance.md
+++ b/meetings/2025/06/attendance.md
@@ -4,9 +4,5 @@ date: June 04, 2025 - June 06, 2026
 permalink: meetings/2025/06/attendance
 year: "2025"
 month: "06"
-prev_year: "2025"
-prev_month: "03"
-prev_prev_year: "2025"
-prev_prev_month: "01"
 ---
 

--- a/meetings/2025/06/votes.md
+++ b/meetings/2025/06/votes.md
@@ -5,8 +5,6 @@ year: "2025"
 month: "06"
 rules: 3152013
 permalink: meetings/2025/06/votes
-registered: 33
 ooe: 30
-imove: 30
 ---
 

--- a/meetings/2025/09/attendance.md
+++ b/meetings/2025/09/attendance.md
@@ -4,10 +4,6 @@ date: September 29, 2025 - October 01, 2025
 permalink: meetings/2025/09/attendance
 year: "2025"
 month: "09"
-prev_year: "2025"
-prev_month: "06"
-prev_prev_year: "2025"
-prev_prev_month: "03"
 ---
 
 **Note:** "VSC Research Center, TU Wien" has been renamed to "ASC Research

--- a/meetings/2025/09/votes.md
+++ b/meetings/2025/09/votes.md
@@ -5,8 +5,6 @@ year: "2025"
 month: "09"
 rules: 3152013
 permalink: meetings/2025/09/votes
-registered: 37
 ooe: 32
-imove: 32
 ---
 

--- a/meetings/2025/12/attendance.md
+++ b/meetings/2025/12/attendance.md
@@ -4,9 +4,5 @@ date: December 15, 2025 - December 17, 2025
 permalink: meetings/2025/12/attendance
 year: "2025"
 month: "12"
-prev_year: "2025"
-prev_month: "09"
-prev_prev_year: "2025"
-prev_prev_month: "06"
 ---
 

--- a/meetings/2025/12/votes.md
+++ b/meetings/2025/12/votes.md
@@ -5,8 +5,6 @@ year: "2025"
 month: "12"
 rules: 3152013
 permalink: meetings/2025/12/votes
-registered: 25
 ooe: 25
-imove: 25
 ---
 

--- a/meetings/2026/03/attendance.md
+++ b/meetings/2026/03/attendance.md
@@ -4,9 +4,5 @@ date: March 02, 2026 - March 05, 2026
 permalink: meetings/2026/03/attendance
 year: "2026"
 month: "03"
-prev_year: "2025"
-prev_month: "12"
-prev_prev_year: "2025"
-prev_prev_month: "09"
 ---
 

--- a/meetings/2026/03/votes.md
+++ b/meetings/2026/03/votes.md
@@ -5,8 +5,6 @@ year: "2026"
 month: "03"
 rules: 3152013
 permalink: meetings/2026/03/votes
-registered: 29
 ooe: 29
-imove: 29
 ---
 

--- a/meetings/2026/06/attendance.md
+++ b/meetings/2026/06/attendance.md
@@ -4,9 +4,5 @@ date: June 01, 2026 - June 04, 2026
 permalink: meetings/2026/06/attendance
 year: "2026"
 month: "06"
-prev_year: "2026"
-prev_month: "03"
-prev_prev_year: "2025"
-prev_prev_month: "12"
 ---
 

--- a/meetings/2026/06/votes.md
+++ b/meetings/2026/06/votes.md
@@ -5,8 +5,6 @@ year: "2026"
 month: "06"
 rules: 3152013
 permalink: meetings/2026/06/votes
-registered:
 ooe:
-imove:
 ---
 


### PR DESCRIPTION
There's a few things that I have to manually update for every meeting that really can be automated:

* The list of current and previous meetings
* The number of voting eligible organizations

This PR moves all of that from `_layouts/attendance.html` to `_includes/header.html` so it can be used in whichever file is needed, then removes the static values from each of the corresponding pages.