### PR TITLE
Update Intel MPI's MPI-5.0 implementation status

### DIFF
--- a/Implementation_Status.md
+++ b/Implementation_Status.md
@@ -11,8 +11,8 @@ This page provides a way to update the community on the current status of variou
 ## MPI 5.0
 
 | ------------------------- | ----- | ------- | ------- |
-| Feature                   | [MPICH](https://mpich.org/) | [Open MPI](https://www.open-mpi.org/)
-| ABI Support                                                            |   ✅+   |      |
+| Feature                   | [MPICH](https://mpich.org/) | [Open MPI](https://www.open-mpi.org/) | [Intel MPI](https://www.intel.com/content/www/us/en/developer/tools/oneapi/mpi-library.html) 
+| ABI Support                                                            |   ✅+   |      |   ✅   |
 
 MPICH’s Fortran binding currently only supports MPICH ABI instead of MPI ABI. The Fortran binding support on top of MPI ABI is currently under development
 


### PR DESCRIPTION
IMPI 2021.18.0, which is a part of oneAPI 2026.0, supports the MPI-5.0 ABI specification.